### PR TITLE
Revert "fix(helm): update chart ingress-nginx ( 4.13.0 → 4.13.1 )"

### DIFF
--- a/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.13.1
+      version: 4.13.0
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx

--- a/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.13.1
+      version: 4.13.0
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx


### PR DESCRIPTION
Reverts patsoffice/home-ops#291 due to https://github.com/kubernetes/ingress-nginx/issues/13598